### PR TITLE
Copy executables into main build directory after linking, addresses #3.

### DIFF
--- a/wscript
+++ b/wscript
@@ -47,6 +47,25 @@ def build(bld):
     bld.recurse('tem')
     bld.recurse('mus')
 
+    if not (bld.cmd == 'docu'):
+        bld.add_group()
+
+        bld(
+            rule = 'cp ${SRC} ${TGT[0].abspath()}',
+            source = bld.path.find_or_declare('mus/musubi'),
+            target = 'musubi'
+        )
+        bld(
+            rule = 'cp ${SRC} ${TGT[0].abspath()}',
+            source = bld.path.find_or_declare('mus/mus_harvesting'),
+            target = 'mus_harvesting'
+        )
+        bld(
+            rule = 'cp ${SRC} ${TGT[0].abspath()}',
+            source = bld.path.find_or_declare('aotus/lua'),
+            target = 'lua'
+        )
+
 #clean build directory and coco completely to create the build from scratch
 def cleanall(ctx):
     from waflib import Options


### PR DESCRIPTION
This additional build group in the main wscript adds copy operations to obtain the executables from the respective subdirectories and provide the original locations for the executables as requested in #3.