### PR TITLE
Add missing reference for ps_cyl2d example

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,4 @@
 [submodule "mus"]
 	path = mus
 	url = ../musubi-source.git
+	branch = ref_ps_cyl2d

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,4 +10,3 @@
 [submodule "mus"]
 	path = mus
 	url = ../musubi-source.git
-	branch = ref_ps_cyl2d


### PR DESCRIPTION
See [PR in musubi-source](https://github.com/apes-suite/musubi-source/pull/36).